### PR TITLE
perf: lazy-load chain bridges to reduce consumer bundle size by ~1.97MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,22 @@
     ".": {
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
+    },
+    "./evm": {
+      "types": "./build/bridge-evm/index.d.ts",
+      "default": "./build/bridge-evm/index.js"
+    },
+    "./ton": {
+      "types": "./build/bridge-ton/index.d.ts",
+      "default": "./build/bridge-ton/index.js"
+    },
+    "./stellar": {
+      "types": "./build/bridge-stellar/index.d.ts",
+      "default": "./build/bridge-stellar/index.js"
+    },
+    "./near": {
+      "types": "./build/bridge-near/index.d.ts",
+      "default": "./build/bridge-near/index.js"
     }
   },
   "sideEffects": false,
@@ -26,7 +42,14 @@
     "@cosmjs/stargate": "0.37.0",
     "@solana/spl-token": "0.4.13",
     "@solana/web3.js": "1.68.0",
-    "cosmjs-types": "0.11.0"
+    "@stellar/stellar-sdk": "14.1.1",
+    "@ton-api/client": "0.4.0",
+    "@ton-api/ton-adapter": "0.4.1",
+    "@ton/core": "0.60.1",
+    "@ton/crypto": "3.3.0",
+    "@ton/ton": "15.2.1",
+    "cosmjs-types": "0.11.0",
+    "ethers": "6.15.0"
   },
   "dependencies": {
     "@near-js/crypto": "2.2.5",
@@ -35,13 +58,6 @@
     "@near-js/types": "2.2.5",
     "@near-js/utils": "2.2.5",
     "@scure/base": "2.0.0",
-    "@stellar/stellar-sdk": "14.1.1",
-    "@ton-api/client": "0.4.0",
-    "@ton-api/ton-adapter": "0.4.1",
-    "@ton/core": "0.60.1",
-    "@ton/crypto": "3.3.0",
-    "@ton/ton": "15.2.1",
-    "ethers": "6.15.0",
     "rlp": "3.0.0"
   },
   "devDependencies": {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -2,7 +2,6 @@ import type { Action } from "@near-js/transactions";
 import { baseEncode } from "@near-js/utils";
 
 import {
-  Logger,
   toOmniIntent,
   encodeReceiver,
   encodeTokenAddress,
@@ -37,12 +36,12 @@ import OmniApi from "./api";
 
 import { INTENTS_CONTRACT, OMNI_HOT_V2, Settings } from "./env";
 import { NEAR_PER_GAS, TGAS, ReviewFee } from "./fee";
+import { Logger } from "./logger";
 import type { SolanaOmniService } from "./bridge-solana";
 import type { CosmosService } from "./bridge-cosmos";
-
-import StellarService from "./bridge-stellar";
-import EvmOmniService from "./bridge-evm";
-import TonOmniService from "./bridge-ton";
+import type StellarService from "./bridge-stellar";
+import type EvmOmniService from "./bridge-evm";
+import type TonOmniService from "./bridge-ton";
 import NearBridge from "./bridge-near";
 
 class HotBridge {
@@ -62,9 +61,6 @@ class HotBridge {
     [Network.Monad]: 200_000n,
   };
 
-  stellar: StellarService;
-  ton: TonOmniService;
-  evm: EvmOmniService;
   near: NearBridge;
   api: OmniApi;
 
@@ -76,29 +72,47 @@ class HotBridge {
     this.api = new OmniApi(options.api, options.mpcApi);
     this.near = new NearBridge(this, options.nearRpc);
 
-    this.evm = new EvmOmniService(this, {
-      enableApproveMax: options.enableApproveMax,
-      treasuryDefaultContract: options.evmTreasuryDefaultContract,
-      treasuryContracts: options.evmTreasuryContracts,
-      rpcs: options.evmRpc,
-    });
-
     this.withdrawFees = Object.assign(this.withdrawFees, options.withdrawFees);
     this.defaultEvmWithdrawFee = options.defaultEvmWithdrawFee || 1_000_000n;
 
-    this.stellar = new StellarService(this, {
-      contract: options.stellarContract,
-      sorobanRpc: options.stellarRpc,
-      horizonRpc: options.stellarHorizonRpc,
-      baseFee: options.stellarBaseFee,
-    });
-
-    this.ton = new TonOmniService(this, {
-      contract: options.tonContract,
-      rpc: options.tonRpc,
-    });
-
     Object.assign(Settings.cosmos, options.cosmos);
+  }
+
+  _evm: EvmOmniService | null = null;
+  async evm() {
+    if (this._evm) return this._evm;
+    const pkg = await import("./bridge-evm");
+    this._evm = new pkg.default(this, {
+      enableApproveMax: this.options.enableApproveMax,
+      treasuryDefaultContract: this.options.evmTreasuryDefaultContract,
+      treasuryContracts: this.options.evmTreasuryContracts,
+      rpcs: this.options.evmRpc,
+    });
+    return this._evm;
+  }
+
+  _stellar: StellarService | null = null;
+  async stellar() {
+    if (this._stellar) return this._stellar;
+    const pkg = await import("./bridge-stellar");
+    this._stellar = new pkg.default(this, {
+      contract: this.options.stellarContract,
+      sorobanRpc: this.options.stellarRpc,
+      horizonRpc: this.options.stellarHorizonRpc,
+      baseFee: this.options.stellarBaseFee,
+    });
+    return this._stellar;
+  }
+
+  _ton: TonOmniService | null = null;
+  async ton() {
+    if (this._ton) return this._ton;
+    const pkg = await import("./bridge-ton");
+    this._ton = new pkg.default(this, {
+      contract: this.options.tonContract,
+      rpc: this.options.tonRpc,
+    });
+    return this._ton;
   }
 
   _solana: SolanaOmniService | null = null;
@@ -148,7 +162,7 @@ class HotBridge {
     }
 
     if (pending.chain === Network.Stellar) {
-      const isUsed = await this.stellar.isWithdrawUsed(pending.nonce);
+      const isUsed = await (await this.stellar()).isWithdrawUsed(pending.nonce);
       this._cacheCompleted[pending.nonce] = isUsed;
       if (isUsed) await data.completedWithoutHash?.(pending);
       else await data.needToExecute?.(pending);
@@ -156,14 +170,14 @@ class HotBridge {
     }
 
     if (isTon(pending.chain)) {
-      const isUsed = await this.ton.isWithdrawUsed(pending.nonce, pending.receiver);
+      const isUsed = await (await this.ton()).isWithdrawUsed(pending.nonce, pending.receiver);
       this._cacheCompleted[pending.nonce] = isUsed;
       if (isUsed) await data.completedWithoutHash?.(pending);
       else await data.needToExecute?.(pending);
       return;
     }
 
-    const isUsed = await this.evm.isWithdrawUsed(pending.chain, pending.nonce);
+    const isUsed = await (await this.evm()).isWithdrawUsed(pending.chain, pending.nonce);
     this._cacheCompleted[pending.nonce] = isUsed;
     if (isUsed) await data.completedWithoutHash?.(pending);
     else await data.needToExecute?.(pending);
@@ -394,11 +408,11 @@ class HotBridge {
   }
 
   async isWithdrawUsed(chain: number, nonce: string, receiver: string) {
-    if (isTon(chain)) return await this.ton.isWithdrawUsed(nonce, receiver);
+    if (isTon(chain)) return await this.ton().then((s) => s.isWithdrawUsed(nonce, receiver));
     if (isCosmos(chain)) return await this.cosmos().then((s) => s.isWithdrawUsed(chain, nonce));
     if (chain === Network.Solana) return await this.solana().then((s) => s.isWithdrawUsed(nonce, receiver));
-    if (chain === Network.Stellar) return await this.stellar.isWithdrawUsed(nonce);
-    return await this.evm.isWithdrawUsed(chain, nonce);
+    if (chain === Network.Stellar) return await this.stellar().then((s) => s.isWithdrawUsed(nonce));
+    return await this.evm().then((s) => s.isWithdrawUsed(chain, nonce));
   }
 
   async getPendingWithdrawal(nonce: string): Promise<WithdrawArgsWithPending> {
@@ -433,11 +447,11 @@ class HotBridge {
 
   async waitPendingDeposit(chain: number, hash: string, intentAccount: string, abort?: AbortSignal): Promise<PendingDepositWithIntent> {
     const waitPending = async () => {
-      if (isTon(chain)) return await this.ton.parseDeposit(hash);
+      if (isTon(chain)) return await this.ton().then((s) => s.parseDeposit(hash));
       if (isCosmos(chain)) return await this.cosmos().then((s) => s.parseDeposit(chain, hash));
       if (chain === Network.Solana) return await this.solana().then((s) => s.parseDeposit(hash));
-      if (chain === Network.Stellar) return await this.stellar.parseDeposit(hash);
-      return await this.evm.parseDeposit(chain, hash);
+      if (chain === Network.Stellar) return await this.stellar().then((s) => s.parseDeposit(hash));
+      return await this.evm().then((s) => s.parseDeposit(chain, hash));
     };
 
     while (true) {
@@ -516,7 +530,8 @@ class HotBridge {
     if (options.chain === Network.Solana) throw new GaslessNotAvailableError(options.chain);
 
     if (options.chain === Network.Stellar) {
-      const exists = await this.stellar.isAccountExists(options.receiver);
+      const stellar = await this.stellar();
+      const exists = await stellar.isAccountExists(options.receiver);
       if (!exists) return { gasPrice: 11000000n, blockNumber: 0n };
       return { gasPrice: 1000000n, blockNumber: 0n };
     }
@@ -525,8 +540,9 @@ class HotBridge {
 
     if ([Network.Ton, Network.OmniTon].includes(options.chain)) return { gasPrice: 40000000n, blockNumber: 0n };
 
-    const { gasPrice } = await this.evm.getProvider(options.chain).getFeeData();
-    const blockNumber = await this.evm.getProvider(options.chain).getBlockNumber();
+    const evmBridge = await this.evm();
+    const { gasPrice } = await evmBridge.getProvider(options.chain).getFeeData();
+    const blockNumber = await evmBridge.getProvider(options.chain).getBlockNumber();
     const gasLimit = this.withdrawFees[options.chain] || this.defaultEvmWithdrawFee;
     const fee = (BigInt(gasPrice || 0n) * 130n) / 100n;
 
@@ -833,22 +849,22 @@ class HotBridge {
       if (fee) return new ReviewFee({ gasless: true, chain, baseFee: BigInt(fee.gasPrice) });
     }
 
-    if (isTon(chain)) return (await this.ton.getWithdrawFee()) as ReviewFee;
+    if (isTon(chain)) return (await this.ton().then((s) => s.getWithdrawFee())) as ReviewFee;
     if (isCosmos(chain)) return (await this.cosmos().then((s) => s.getWithdrawFee(chain))) as ReviewFee;
     if (chain === Network.Solana) return (await this.solana().then((s) => s.getWithdrawFee())) as ReviewFee;
-    if (chain === Network.Stellar) return (await this.stellar.getWithdrawFee()) as ReviewFee;
-    return (await this.evm.getWithdrawFee(chain)) as ReviewFee;
+    if (chain === Network.Stellar) return (await this.stellar().then((s) => s.getWithdrawFee())) as ReviewFee;
+    return (await this.evm().then((s) => s.getWithdrawFee(chain))) as ReviewFee;
   }
 
   async getDepositFee(options: { chain: number; token: string; amount: bigint; sender: string; intentAccount: string }): Promise<ReviewFee> {
     const { chain, token, amount, sender, intentAccount } = options;
     if (chain === Network.Hot) return new ReviewFee({ gasless: true, chain });
     if (chain === Network.Near) return new ReviewFee({ gasless: true, baseFee: NEAR_PER_GAS, gasLimit: 300n * TGAS, chain });
-    if (chain === Network.Stellar) return (await this.stellar.getDepositFee(sender, token, amount, intentAccount)) as ReviewFee;
+    if (chain === Network.Stellar) return (await this.stellar().then((s) => s.getDepositFee(sender, token, amount, intentAccount))) as ReviewFee;
     if (isCosmos(chain)) return (await this.cosmos().then((s) => s.getDepositFee(chain, sender, token, amount, intentAccount))) as ReviewFee;
     if (chain === Network.Solana) return (await this.solana().then((s) => s.getDepositFee(token))) as ReviewFee;
-    if (isTon(chain)) return (await this.ton.getDepositFee(token)) as ReviewFee;
-    return (await this.evm.getDepositFee(chain, token, amount, sender)) as ReviewFee;
+    if (isTon(chain)) return (await this.ton().then((s) => s.getDepositFee(token))) as ReviewFee;
+    return (await this.evm().then((s) => s.getDepositFee(chain, token, amount, sender))) as ReviewFee;
   }
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,8 @@
+export class Logger {
+  warn(...args: any[]) {
+    console.warn(...args);
+  }
+  log(...args: any[]) {
+    console.log(...args);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type { Action } from "@near-js/transactions";
 import type { Connection } from "@solana/web3.js";
 import type { AbstractProvider } from "ethers";
 
-import { Logger } from "./utils";
+import { Logger } from "./logger";
 import { CosmosConfig } from "./env";
 
 export enum Network {

--- a/tests/getGaslessWithdrawFee.test.ts
+++ b/tests/getGaslessWithdrawFee.test.ts
@@ -55,7 +55,8 @@ describe("HotBridge.getGaslessWithdrawFee", () => {
       const MOCK_BLOCK_NUMBER = 99999n;
 
       bridge.withdrawFees = { [Network.Eth]: 100_000n };
-      bridge.evm.getProvider = vi.fn().mockReturnValue({
+      const evmBridge = await bridge.evm();
+      evmBridge.getProvider = vi.fn().mockReturnValue({
         getFeeData: vi.fn().mockResolvedValue({ gasPrice: MOCK_GAS_PRICE }),
         getBlockNumber: vi.fn().mockResolvedValue(MOCK_BLOCK_NUMBER),
       });
@@ -75,7 +76,8 @@ describe("HotBridge.getGaslessWithdrawFee", () => {
       const MOCK_BLOCK_NUMBER = 99999n;
 
       bridge.withdrawFees = {};
-      bridge.evm.getProvider = vi.fn().mockReturnValue({
+      const evmBridge = await bridge.evm();
+      evmBridge.getProvider = vi.fn().mockReturnValue({
         getFeeData: vi.fn().mockResolvedValue({ gasPrice: MOCK_GAS_PRICE }),
         getBlockNumber: vi.fn().mockResolvedValue(MOCK_BLOCK_NUMBER),
       });

--- a/tests/lazy-loading.test.ts
+++ b/tests/lazy-loading.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+import HotBridge from "../src/bridge";
+
+describe("HotBridge lazy-loading", () => {
+  const bridge = new HotBridge({});
+
+  it("evm() should return an EvmOmniService instance", async () => {
+    const evm = await bridge.evm();
+    expect(evm).toBeDefined();
+    expect(typeof evm.getProvider).toBe("function");
+    expect(typeof evm.isWithdrawUsed).toBe("function");
+  });
+
+  it("evm() should return the same cached instance on second call", async () => {
+    const first = await bridge.evm();
+    const second = await bridge.evm();
+    expect(first).toBe(second);
+  });
+
+  it("ton() should return a TonOmniService instance", async () => {
+    const ton = await bridge.ton();
+    expect(ton).toBeDefined();
+    expect(typeof ton.isWithdrawUsed).toBe("function");
+    expect(typeof ton.deposit).toBe("function");
+  });
+
+  it("ton() should return the same cached instance on second call", async () => {
+    const first = await bridge.ton();
+    const second = await bridge.ton();
+    expect(first).toBe(second);
+  });
+
+  it("stellar() should return a StellarService instance", async () => {
+    const stellar = await bridge.stellar();
+    expect(stellar).toBeDefined();
+    expect(typeof stellar.isWithdrawUsed).toBe("function");
+  });
+
+  it("stellar() should return the same cached instance on second call", async () => {
+    const first = await bridge.stellar();
+    const second = await bridge.stellar();
+    expect(first).toBe(second);
+  });
+
+  it("solana() should return a SolanaOmniService instance", async () => {
+    const solana = await bridge.solana();
+    expect(solana).toBeDefined();
+    expect(typeof solana.isWithdrawUsed).toBe("function");
+  });
+
+  it("cosmos() should return a CosmosService instance", async () => {
+    const cosmos = await bridge.cosmos();
+    expect(cosmos).toBeDefined();
+  });
+
+  it("near should be available synchronously", () => {
+    expect(bridge.near).toBeDefined();
+    expect(typeof bridge.near.viewFunction).toBe("function");
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+
+import { encodeTokenAddress, decodeTokenAddress, encodeReceiver, decodeReceiver } from "../src/utils";
+import { Network } from "../src/types";
+
+describe("utils - address encoding (@scure/base hex)", () => {
+  const evmAddress = "0x391E7C679d29bD940d63be94AD22A25d25b5A604";
+
+  it("EVM token address should roundtrip encode/decode", () => {
+    const encoded = encodeTokenAddress(Network.Eth, evmAddress);
+    const decoded = decodeTokenAddress(Network.Eth, encoded);
+    expect(decoded).toBe(evmAddress.toLowerCase());
+  });
+
+  it("EVM receiver should roundtrip encode/decode", () => {
+    const encoded = encodeReceiver(Network.Eth, evmAddress);
+    const decoded = decodeReceiver(Network.Eth, encoded);
+    expect(decoded).toBe(evmAddress.toLowerCase());
+  });
+
+  it("EVM native should encode/decode correctly", () => {
+    expect(encodeTokenAddress(Network.Eth, "native")).toBe("11111111111111111111");
+    expect(decodeTokenAddress(Network.Eth, "11111111111111111111")).toBe("native");
+  });
+});


### PR DESCRIPTION
 Kit PR hot-dao/kit#7 removed direct chain SDK imports from kit's core, saving ~295KB. But consumers importing HotBridge, ReviewFee, or utils from @hot-labs/omni-sdk still pull all chain SDKs eagerly (~1.97MB) regardless of which chains they actually use.

  **List of improvements:**
  - Extract Logger class to src/logger.ts - breaks the types.ts → utils.ts → all chain SDKs import chain, so `import { Network }` is now lightweight
  - Replace ethers getBytes/hexlify with @scure/base hex codec in utils.ts - removes ethers (~291KB bundled) from utils import path (@scure/base was already a dependency)
  - Replace `import TonOmniService from "./bridge-ton"` with direct imports from bridge-ton/jettons.ts (pure data, zero deps) — removes @ton-api/* (~95KB) from utils path
  - Lazy-load EVM, TON, Stellar bridges using the same async pattern already used for Solana/Cosmos
  - Move ethers, @stellar/stellar-sdk, @ton/*, @ton-api/* from dependencies to optionalDependencies
  - Add sub-path exports: ./evm, ./ton, ./stellar, ./near for per-chain imports

  **Results (consumer bundle impact)**
  ethers (via utils) — 291 KB >> 0 KB
  @stellar/stellar-sdk (via HotBridge) - ~1,381 KB >> 0 KB (lazy, loads on first stellar() call)
  @ton/core + @ton/ton (via HotBridge) - ~200 KB >> 0 KB (lazy, loads on first ton() call)
  @ton-api/* (via utils→TonOmniService) - ~95 KB >> 0 KB
  Total consumer bundle reduction: ~1,967 KB deferred until actual chain usage

  !IMPORTANT! **Breaking change:** bridge.evm / bridge.ton / bridge.stellar properties → async methods.
  Migration: `bridge.evm.deposit()` → `(await bridge.evm()).deposit()`. TypeScript catches this at compile time.

  **Tests:**
tsc, 22 tests passing - EVM address encoding roundtrips validating @scure/base hex replacement (utils.test.ts), lazy bridge instantiation and singleton caching for all 5 chains (lazy-loading.test.ts), getGaslessWithdrawFee with mocked EVM provider updated to async bridge pattern (getGaslessWithdrawFee.test.ts)